### PR TITLE
Add service for cross-stream

### DIFF
--- a/Formula/cross-stream.rb
+++ b/Formula/cross-stream.rb
@@ -10,6 +10,10 @@ class CrossStream < Formula
     bin.install "xs"
   end
 
+  service do
+    run [opt_bin/"xs", "serve", File.join(Dir.home, ".local/share/cross.stream/store")]
+  end
+
   test do
     system "#{bin}/xs", "--version"
   end


### PR DESCRIPTION
## Summary
- add a simple Homebrew `service` block for `cross-stream`

## Testing
- `brew help >/dev/null` *(fails: 'brew' not found)*